### PR TITLE
Workaround id3 decoding error in some cases for mp3 files

### DIFF
--- a/src/xm.rs
+++ b/src/xm.rs
@@ -132,7 +132,10 @@ impl From<Tag> for XMInfo {
                 .map(|f| f.content().text().unwrap_or_default().to_string()),
             encoding_technology: value
                 .get("TSSE")
-                .map(|f| f.content().text().unwrap_or_default().to_string()),
+                // For mp3 files, this value can be something like "\0\0qTwMiLAAAJ3L79",
+                // which we need to change to "//qTwMiLAAAJ3L79" for it to be base64 decodable.
+                // This seems to be a bug in the ID3 library
+                .map(|f| f.content().text().unwrap_or_default().to_string().replace('\0', '/')),
         }
     }
 }
@@ -166,7 +169,9 @@ impl XMInfo {
         } else if header_str.contains("wav") {
             "wav"
         } else {
-            "m4a"
+            // header_str: h"dy$bit@slb1n>^&pa`im#hlzw?
+            // in this case, it's likely an mp3 file that has no dedicated magic string
+			"mp3"
         };
 
         format!(


### PR DESCRIPTION
你好，我在使用中发现有些`*.xm`文件解密失败，后来发现应该是`id3`解码出了点问题，这个PR就是修正这个问题的。你可以用附件这个文件测试比较一下。
[26.zip](https://github.com/jupitergao18/xm_decryptor/files/14907233/26.zip)
